### PR TITLE
Add option to limit number of chunks enqueued

### DIFF
--- a/src/SplitStream/SplitStreamOptions.cs
+++ b/src/SplitStream/SplitStreamOptions.cs
@@ -4,6 +4,7 @@
     {
         public int ChunkSize { get; set; }
         public bool SanityCheckOnDispose { get; set; }
+        public int MaxEnqueuedChunks { get; set; }
 
         public SplitStreamOptions SetChunkSize(int chunkSize)
         {
@@ -14,7 +15,8 @@
         public static SplitStreamOptions Default => new SplitStreamOptions
         {
             SanityCheckOnDispose = false,
-            ChunkSize = ushort.MaxValue
+            ChunkSize = ushort.MaxValue,
+            MaxEnqueuedChunks = int.MaxValue
         };
     }
 }


### PR DESCRIPTION
To prevent an OOM issue in case of fast readahead but slower stream
reading on large files where too many chunks are enqueued, add an option
to limit the number of chunks enqueued per stream.